### PR TITLE
Wip: Add Shift register

### DIFF
--- a/src/display/interface.rs
+++ b/src/display/interface.rs
@@ -2,9 +2,11 @@ use crate::display::traits::Command;
 use core::marker::PhantomData;
 
 use embedded_hal::{
-    blocking::{delay::*, spi::Write},
-    digital::v2::{InputPin, OutputPin},
+    blocking::spi::Write,
+    digital::v2::OutputPin,
 };
+
+use super::IsBusy;
 /// Interface for the display
 pub(crate) struct DisplayInterface<SPI, CS, DC, RST> {
     /// SPI
@@ -105,8 +107,8 @@ where
     }
 
     /// waits until the device is not busy
-    pub(crate) fn wait_until_idle(&mut self, timeout: u8) {
-        // while self.is_busy(timeout) {}
+    pub(crate) fn wait_until_idle(&mut self, busy_signal: &mut impl IsBusy) {
+        while busy_signal.is_busy() {}
     }
 
     /// Checks if device is still busy - use a timeout since we don't have a busy pin on the inky-frame
@@ -115,11 +117,11 @@ where
     //     return true;
     // }
 
-    pub(crate) fn reset(&mut self) {
+    pub(crate) fn reset(&mut self, busy_signal: &mut impl IsBusy) {
         let _ = self.rst.set_low();
         // delay.delay_ms(10);
         let _ = self.rst.set_high();
         // delay.delay_ms(10);
-        // self.wait_until_idle(200, delay);
+        self.wait_until_idle(busy_signal);
     }
 }

--- a/src/display/interface.rs
+++ b/src/display/interface.rs
@@ -6,11 +6,9 @@ use embedded_hal::{
     digital::v2::{InputPin, OutputPin},
 };
 /// Interface for the display
-pub(crate) struct DisplayInterface<SPI, CS, DC, RST, DELAY> {
+pub(crate) struct DisplayInterface<SPI, CS, DC, RST> {
     /// SPI
     _spi: PhantomData<SPI>,
-    /// DELAY
-    _delay: PhantomData<DELAY>,
     /// Chip Select for SPI
     cs: CS,
     /// Data/Command Control Pin (High for data, Low for command)
@@ -19,18 +17,16 @@ pub(crate) struct DisplayInterface<SPI, CS, DC, RST, DELAY> {
     rst: RST,
 }
 
-impl<SPI, CS, DC, RST, DELAY> DisplayInterface<SPI, CS, DC, RST, DELAY>
+impl<SPI, CS, DC, RST> DisplayInterface<SPI, CS, DC, RST>
 where
     SPI: Write<u8>,
     CS: OutputPin,
     DC: OutputPin,
     RST: OutputPin,
-    DELAY: DelayMs<u8>,
 {
     pub fn new(cs: CS, dc: DC, rst: RST) -> Self {
         DisplayInterface {
             _spi: PhantomData::default(),
-            _delay: PhantomData::default(),
             cs,
             dc,
             rst,
@@ -109,21 +105,21 @@ where
     }
 
     /// waits until the device is not busy
-    pub(crate) fn wait_until_idle(&mut self, timeout: u8, delay: &mut DELAY) {
-        while self.is_busy(timeout, delay) {}
+    pub(crate) fn wait_until_idle(&mut self, timeout: u8) {
+        // while self.is_busy(timeout) {}
     }
 
     /// Checks if device is still busy - use a timeout since we don't have a busy pin on the inky-frame
-    pub(crate) fn is_busy(&mut self, timeout: u8, delay: &mut DELAY) -> bool {
-        delay.delay_ms(timeout);
-        return true;
-    }
+    // pub(crate) fn is_busy(&mut self, timeout: u8) -> bool {
+    //     delay.delay_ms(timeout);
+    //     return true;
+    // }
 
-    pub(crate) fn reset(&mut self, delay: &mut DELAY) {
+    pub(crate) fn reset(&mut self) {
         let _ = self.rst.set_low();
-        delay.delay_ms(10);
+        // delay.delay_ms(10);
         let _ = self.rst.set_high();
-        delay.delay_ms(10);
-        self.wait_until_idle(200, delay);
+        // delay.delay_ms(10);
+        // self.wait_until_idle(200, delay);
     }
 }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -17,8 +17,8 @@ use color::OctColor;
 pub use display::Display5in65f;
 pub use traits::IsBusy;
 use embedded_hal::{
-    blocking::{delay::*, spi::Write},
-    digital::v2::{InputPin, OutputPin},
+    blocking::spi::Write,
+    digital::v2::OutputPin,
 };
 
 use self::command::Command;
@@ -49,18 +49,18 @@ where
     pub const WIDTH: u32 = WIDTH;
     pub const HEIGHT: u32 = HEIGHT;
 
-    pub fn new(spi: &mut SPI, cs: CS, dc: DC, rst: RST) -> Result<Self, SPI::Error> {
+    pub fn new(spi: &mut SPI, cs: CS, dc: DC, rst: RST, busy_signal: &mut impl IsBusy) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, dc, rst);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd5in65f { interface, color };
-        epd.init(spi)?;
+        epd.init(spi, busy_signal)?;
 
         Ok(epd)
     }
 
-    fn init(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-        self.interface.reset();
+    fn init(&mut self, spi: &mut SPI, busy_signal: &mut impl IsBusy  ) -> Result<(), SPI::Error> {
+        self.interface.reset(busy_signal);
 
         self.cmd_with_data(spi, Command::PanelSetting, &[0xEF, 0x08])?;
         self.cmd_with_data(spi, Command::PowerSetting, &[0x37, 0x00, 0x23, 0x23])?;
@@ -83,49 +83,50 @@ where
         self.interface.cmd(spi, Command::PowerOff)
     }
 
-    pub fn wake_up(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-        self.init(spi)
+    pub fn wake_up(&mut self, spi: &mut SPI, busy_signal: &mut impl IsBusy) -> Result<(), SPI::Error> {
+        self.init(spi, busy_signal)
     }
 
     pub fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         self.cmd_with_data(spi, Command::DeepSleep, &[0xA5])
     }
 
-    pub fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
-        self.busy_wait();
+    pub fn update_frame(&mut self, spi: &mut SPI, busy_signal: &mut impl IsBusy , buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.busy_wait(busy_signal);
         self.update_vcom(spi)?;
         self.send_resolution(spi)?;
         self.cmd_with_data(spi, Command::DataStartTransmission1, buffer)
     }
 
-    pub fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-        self.busy_wait();
+    pub fn display_frame(&mut self, spi: &mut SPI, busy_signal: &mut impl IsBusy) -> Result<(), SPI::Error> {
+        self.busy_wait(busy_signal);
         self.command(spi, Command::PowerOn)?;
-        self.busy_wait();
+        self.busy_wait(busy_signal);
         self.command(spi, Command::DisplayRefresh)?;
-        self.busy_wait();
+        self.busy_wait(busy_signal);
         self.command(spi, Command::PowerOff)?;
-        self.busy_wait();
+        self.busy_wait(busy_signal);
         Ok(())
     }
 
     pub fn update_and_display_frame(
         &mut self,
         spi: &mut SPI,
+        busy_signal: &mut impl IsBusy,
         buffer: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.update_frame(spi, buffer)?;
-        self.display_frame(spi)?;
+        self.update_frame(spi, busy_signal, buffer)?;
+        self.display_frame(spi, busy_signal)?;
         Ok(())
     }
 
-    pub fn clear_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+    pub fn clear_frame(&mut self, spi: &mut SPI, busy_signal: &mut impl IsBusy) -> Result<(), SPI::Error> {
         let bg = OctColor::colors_byte(self.color, self.color);
-        self.busy_wait();
+        self.busy_wait(busy_signal);
         self.update_vcom(spi)?;
         self.send_resolution(spi)?;
         self.command(spi, Command::DataStartTransmission1)?;
-        self.display_frame(spi)?;
+        self.display_frame(spi, busy_signal)?;
         Ok(())
     }
 
@@ -175,7 +176,7 @@ where
         Ok(())
     }
 
-    fn busy_wait(&mut self) {
-        // self.interface.wait_until_idle(100, delay)
+    fn busy_wait(&mut self, busy_signal: &mut impl IsBusy) {
+        self.interface.wait_until_idle(busy_signal)
     }
 }

--- a/src/display/traits.rs
+++ b/src/display/traits.rs
@@ -3,3 +3,7 @@
 pub(crate) trait Command {
     fn address(self) -> u8;
 }
+
+pub trait IsBusy {
+    fn is_busy(&mut self) -> bool;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,6 @@
 #[cfg(feature = "display")]
 pub mod display;
 
+pub mod shift_register;
+
 pub use display::Display5in65f;

--- a/src/shift_register.rs
+++ b/src/shift_register.rs
@@ -1,0 +1,73 @@
+use crate::display::IsBusy;
+use embedded_hal::digital::v2::{InputPin, OutputPin};
+pub struct InkyFrameShiftRegister<GpioOutput, GpioInput> {
+    clock_pin: GpioOutput,
+    latch_pin: GpioOutput,
+    out_pin: GpioInput,
+}
+
+const IS_BUSY_FLAG: u8 = 7;
+
+impl<GpioOutput, GpioInput> InkyFrameShiftRegister<GpioOutput, GpioInput>
+where
+    GpioOutput: OutputPin,
+    GpioInput: InputPin,
+{
+    pub fn new(clock_pin: GpioOutput, latch_pin: GpioOutput, out_pin: GpioInput) -> Self {
+        InkyFrameShiftRegister {
+            clock_pin,
+            latch_pin,
+            out_pin,
+        }
+    }
+
+    pub fn read_register<
+        E: core::convert::From<<GpioInput as embedded_hal::digital::v2::InputPin>::Error>
+            + core::convert::From<<GpioOutput as embedded_hal::digital::v2::OutputPin>::Error>,
+    >(
+        &mut self,
+    ) -> Result<u8, E> {
+        self.latch_pin.set_low()?;
+        self.latch_pin.set_high()?;
+        let mut result = 0u8;
+        let mut bits = 0u8;
+
+        while bits > 0 {
+            bits -= 1;
+            result <<= 1;
+            if self.out_pin.is_high()? {
+                result |= 1;
+            } else {
+                result |= 0;
+            }
+            self.clock_pin.set_low()?;
+            self.clock_pin.set_high()?;
+        }
+
+        Ok(result)
+    }
+
+    pub fn read_register_bit<
+        E: core::convert::From<<GpioInput as embedded_hal::digital::v2::InputPin>::Error>
+            + core::convert::From<<GpioOutput as embedded_hal::digital::v2::OutputPin>::Error>,
+    >(
+        &mut self,
+        bit_index: u8,
+    ) -> Result<u8, E> {
+        Ok(self.read_register::<E>()? & (1u8 << bit_index))
+    }
+}
+
+impl<GpioOutput, GpioInput> IsBusy for InkyFrameShiftRegister<GpioOutput, GpioInput>
+where
+    GpioOutput: OutputPin,
+    GpioInput: InputPin,
+{
+    fn is_busy(&mut self) -> bool {
+        if let Ok(res) = self.read_register_bit(IS_BUSY_FLAG) {
+            return res == 0;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/shift_register.rs
+++ b/src/shift_register.rs
@@ -25,7 +25,7 @@ where
         self.latch_pin.set_low()?;
         self.latch_pin.set_high()?;
         let mut result = 0u8;
-        let mut bits = 0u8;
+        let mut bits = 8u8;
 
         while bits > 0 {
             bits -= 1;


### PR DESCRIPTION
## What does this PR do? 

- Adds a new isBusy trait that will eventually replace the `isBusy` function in the display struct. The Pico-W version of the inky frame actually has a Shift Register that can signal if it's busy or not. 
- Adds a new `ShiftRegister` struct that implements `isBusy`. 

## What still needs to be done? 

1. Get this to compile - I'd like to use the `?` for the results where possible, but the error type on GPIO types being trait types makes it a bit difficult to compile. 
   1. In a pinch, they should all be safe to unwrap since (at least for the Pico W version) they're all `Infallible` errors. See [embassy-rs/embassy/embassy-rp/gpio](https://github.com/embassy-rs/embassy/blob/589a16b255170ebd45f91dd54a5c1ecc10ce390f/embassy-rp/src/gpio.rs#L1001)
2. See if we can read from the shift register on the Inky Frame. 
